### PR TITLE
metadata: add support for GNOME 44

### DIFF
--- a/pin-app-folders-to-dash@fcusr.github.com/metadata.json
+++ b/pin-app-folders-to-dash@fcusr.github.com/metadata.json
@@ -3,6 +3,9 @@
     "name": "Pin App Folders to Dash",
     "description": "Allow to pin app folders to dash.",
     "version": 2,
-    "shell-version": ["43"],
+    "shell-version": [
+        "43",
+        "44"
+    ],
     "url": "https://github.com/fcusr/pin-app-folders-to-dash"
 }


### PR DESCRIPTION
I've added the "44" tag to the `metadata.json` file of my local installation of "Pin App Folders to Dash" and I've been using a it on GNOME 44 for a few days without any issues.

Thanks for developing this extension! 🚀 